### PR TITLE
Include HTML templates in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wooper-dev"
-version = "0.3.0"
+version = "0.3.1"
 description = "A nix thing"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ dev = [
 ]
 
 [tool.setuptools.package-data]
-wooper_dev = ["quickshell.lock.json"]
+wooper_dev = ["quickshell.lock.json", "templates/*.html"]


### PR DESCRIPTION
## Summary
- Add `templates/*.html` to setuptools package-data so the `index.html` template is included when the package is built

## Test plan
- [ ] Verify the package builds correctly with the template included